### PR TITLE
Changes: purge placeholder entries on startup and block future test data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,8 @@ void main() async {
 
 //initialize  money db
   await expenses_database.initialize();
+  // Purge known test data once at startup (safe no-op if none exist)
+  await expenses_database.purgeTestData();
 
   runApp(MultiProvider(
     providers: [

--- a/lib/money/database/expenses_database.dart
+++ b/lib/money/database/expenses_database.dart
@@ -15,6 +15,25 @@ static  Future<void> initialize() async{
   final dir = await getApplicationDocumentsDirectory();
   isar = await Isar.open([ExpensesSchema], directory: dir.path);
 }
+
+// Purge known test/placeholder data
+static Future<int> purgeTestData({List<String> blacklist = const ["asd", "ok", "new"]}) async {
+  int deleted = 0;
+  // delete any expenses whose name matches any blacklisted value (case-insensitive)
+  for (final raw in blacklist) {
+    final name = raw.toLowerCase();
+    final ids = await isar.expenses
+        .filter()
+        .nameEqualTo(name, caseSensitive: false)
+        .idProperty()
+        .findAll();
+    if (ids.isEmpty) continue;
+    await isar.writeTxn(() async {
+      deleted += await isar.expenses.deleteAll(ids);
+    });
+  }
+  return deleted;
+}
 /*
 GETTERS
 */


### PR DESCRIPTION
- add expenses_database.purgeTestData() to remove case-insensitive exact matches for [asd,ok,new]
- call purge at app startup after Isar init
- add UI validation in Homepage: block placeholder names, require name length >= 2, and amount > 0 on create/edit; show SnackBar on invalid input
- no schema changes; safe no-op if no placeholders present