### PR TITLE
feat: Separate development/test and production data stores

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:trackerop/NewhomePage.dart';
 import 'package:trackerop/money/database/expenses_database.dart';
 import 'package:trackerop/money/models/expenses.dart';
+import 'package:flutter/foundation.dart' show kDebugMode;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -24,10 +25,20 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final Widget home = const NewhomePage();
+    final Widget wrappedHome = (kDebugMode && expenses_database.isTestMode)
+        ? Banner(
+            message: 'TEST DATA',
+            location: BannerLocation.topStart,
+            color: Colors.redAccent,
+            child: home,
+          )
+        : home;
+
     return MaterialApp(
       title: 'Flutter Demo',
       debugShowCheckedModeBanner: false,
-      home: NewhomePage(),
+      home: wrappedHome,
     );
   }
 }


### PR DESCRIPTION
**Description**
This PR addresses the issue of mixing development/test data with actual user data by implementing environment-based database separation.

**Changes Made**

- Database Separation: Uses distinct Isar database names (ex_tracker_test for test mode, ex_tracker_prod for production) to ensure data isolation.
- Environment Override: Honors --dart-define=USE_TEST_DB in all build modes, accepting values like true/false/1/0/yes/no (case-insensitive).
- Default Behavior: 
- Debug builds default to test mode (to avoid mixing with prod data).
- Release builds default to production mode.

- Visual Indicator: Shows a red "TEST DATA" banner in debug builds when using the test database.
- Logging: Logs the selected database mode, name, and directory at startup for easy verification in device logs (e.g., logcat).
- Exposed Properties: Added expenses_database.isTestMode and currentDbName for runtime checks.
- Usage Examples
- Debug (test DB, default): flutter run
- Debug (prod DB): flutter run --dart-define=USE_TEST_DB=false
Release (prod DB, default): flutter run --release
- Release (test DB): flutter run --release --dart-define=USE_TEST_DB=true
- Testing
- Verified database switching via logs and data isolation.
- No breaking changes to existing functionality.
- Clean rebuild recommended after changing defines